### PR TITLE
Added some more customization options to flash message

### DIFF
--- a/lib/flash_messages_helper.rb
+++ b/lib/flash_messages_helper.rb
@@ -13,11 +13,13 @@ module FlashMessagesHelper
   end
 
   class Configuration
-     attr_accessor :css_class, :dom_id, :wrapper
+     attr_accessor :css_class, :dom_id, :wrapper, :prefix_html, :sufix_html
      def initialize
-       @css_class = lambda { |key| "#{key}" }
-       @dom_id    = lambda { |key| "flash-#{key}" }
-       @wrapper   = :div
+       @css_class   = lambda { |key| "#{key}" }
+       @dom_id      = lambda { |key| "flash-#{key}" }
+       @sufix_html  = ""
+       @prefix_html = ""
+       @wrapper     = :div
      end
    end
 
@@ -48,10 +50,12 @@ module FlashMessagesHelper
     def flash_messages(options = {})
       ret = []
       flash.each do |key, value|
+        value = [FlashMessagesHelper.configuration.prefix_html, value, FlashMessagesHelper.configuration.sufix_html].join('')
         ret << content_tag(FlashMessagesHelper.configuration.wrapper, value, {
             :class => FlashMessagesHelper.configuration.css_class.call(key),
             :id    => FlashMessagesHelper.configuration.dom_id.call(key)
-          }.merge(options)
+            }.merge(options),
+            false
         )
       end
       return_string = ret.join("\n")

--- a/lib/flash_messages_helper.rb
+++ b/lib/flash_messages_helper.rb
@@ -13,11 +13,11 @@ module FlashMessagesHelper
   end
 
   class Configuration
-     attr_accessor :css_class, :dom_id, :wrapper, :prefix_html, :sufix_html
+     attr_accessor :css_class, :dom_id, :wrapper, :prefix_html, :suffix_html
      def initialize
        @css_class   = lambda { |key| "#{key}" }
        @dom_id      = lambda { |key| "flash-#{key}" }
-       @sufix_html  = ""
+       @suffix_html  = ""
        @prefix_html = ""
        @wrapper     = :div
      end
@@ -50,7 +50,7 @@ module FlashMessagesHelper
     def flash_messages(options = {})
       ret = []
       flash.each do |key, value|
-        value = [FlashMessagesHelper.configuration.prefix_html, value, FlashMessagesHelper.configuration.sufix_html].join('')
+        value = [FlashMessagesHelper.configuration.prefix_html, value, FlashMessagesHelper.configuration.suffix_html].join('')
         ret << content_tag(FlashMessagesHelper.configuration.wrapper, value, {
             :class => FlashMessagesHelper.configuration.css_class.call(key),
             :id    => FlashMessagesHelper.configuration.dom_id.call(key)

--- a/spec/flash_messages_helper_spec.rb
+++ b/spec/flash_messages_helper_spec.rb
@@ -45,6 +45,13 @@ describe FlashMessagesHelper do
     @view.flash_messages.should == "<p class=\"error\" id=\"flash-error\">There was an error</p>"
   end
 
+  it "will return error message with external text" do
+    FlashMessagesHelper.configuration.prefix_html = "<a href='#' class='close'>x</a>"
+    FlashMessagesHelper.configuration.sufix_html = "<a href='#' class='close'>x</a>"
+    @controller.stub!(:flash).and_return({ :error => 'There was an error' })
+    @view.flash_messages.should == "<div class=\"error\" id=\"flash-error\"><a href='#' class='close'>x</a>There was an error<a href='#' class='close'>x</a></div>"
+  end
+
   it 'will still honor the html options passed in' do
     @controller.stub!(:flash).and_return({ :error => 'There was an error' })
     @view.flash_messages(:class => 'my-class').should == "<div class=\"my-class\" id=\"flash-error\">There was an error</div>"

--- a/spec/flash_messages_helper_spec.rb
+++ b/spec/flash_messages_helper_spec.rb
@@ -47,7 +47,7 @@ describe FlashMessagesHelper do
 
   it "will return error message with external text" do
     FlashMessagesHelper.configuration.prefix_html = "<a href='#' class='close'>x</a>"
-    FlashMessagesHelper.configuration.sufix_html = "<a href='#' class='close'>x</a>"
+    FlashMessagesHelper.configuration.suffix_html = "<a href='#' class='close'>x</a>"
     @controller.stub!(:flash).and_return({ :error => 'There was an error' })
     @view.flash_messages.should == "<div class=\"error\" id=\"flash-error\"><a href='#' class='close'>x</a>There was an error<a href='#' class='close'>x</a></div>"
   end


### PR DESCRIPTION
I add prefix and suffix html options to flash message.

It may be useful in case when we need to show something like this:

``` html
<div class="alert-message warning">
    <a class="close" href="#">×</a>
    <p><strong>Holy guacamole!</strong> Best check yo self, you’re not looking too good.</p>
</div>
```

http://twitter.github.com/bootstrap/index.html#alerts

When we should always to show close link.
